### PR TITLE
Implement the encryption part for B2B direct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Formi9.configure do |config|
   config.partner_id = 'Your Partner Id'
   config.username = 'Your username'
   config.password = 'Your password'
+  # config.b2b_encryption_key = 'key'
+  # config.b2b_encryption_iv = 'iv'
 end
 ```
 

--- a/formi9.gemspec
+++ b/formi9.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", ">= 1.17"
+  spec.add_development_dependency "bundler", "> 2.0.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", ">= 3.9.0"
   spec.add_development_dependency "pry"

--- a/lib/formi9/client.rb
+++ b/lib/formi9/client.rb
@@ -5,5 +5,6 @@ module Formi9
 
     include Formi9::Client::Companies
     include Formi9::Client::Eformi9
+    include Formi9::Client::B2b
   end
 end

--- a/lib/formi9/client/b2b.rb
+++ b/lib/formi9/client/b2b.rb
@@ -1,0 +1,43 @@
+require "base64"
+require 'openssl'
+require 'faraday'
+
+module Formi9
+  class Client
+    module B2b
+      
+      # options = {
+      #   b2b_username: 'Ryan Lyu'
+      #   company_id: 'workstreamdemo',
+      #   request_id: 'AUniqueId',
+      #   result_id: 'AUniqueId'
+      # }
+      def b2b_direct_link(options)
+        string = "AlliancePartnerID=#{CGI.escape(partner_id)}"
+        string << "&AlliancePartnerLogin=#{CGI.escape(username)}"
+        string << "&AlliancePartnerPassword=#{CGI.escape(password)}"
+        string << "&AlliancePartnerCompanyID=#{CGI.escape(options[:company_id])}"
+        string << "&Target=DirectLink&B2BUserName=#{CGI.escape(options[:b2b_username])}"
+        string << "&RequestID=#{CGI.escape(options[:request_id])}"
+        string << "&ResultID=#{CGI.escape(options[:result_id])}&"
+
+        data = b2b_encrypt(string)
+
+        "https://www.formi9.com/FormI9Verify/FormI9LoginService.aspx?EPID=#{partner_id}&EDATA=#{data}"
+      end
+
+
+      def b2b_encrypt(string)
+        cipher = b2b_encryption_algorithm.new(b2b_encryption_cipher_mode) 
+        cipher.encrypt
+        cipher.key = b2b_encryption_key
+        cipher.iv = b2b_encryption_iv
+        encrypted_string = cipher.update(string)
+        encrypted_string << cipher.final
+
+        base64_string = Base64.strict_encode64(encrypted_string)
+        escaped_data = CGI.escape(base64_string)
+      end
+    end
+  end
+end

--- a/lib/formi9/configuration.rb
+++ b/lib/formi9/configuration.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'openssl'
 require File.expand_path('../version', __FILE__)
 
 module Formi9
@@ -19,6 +20,10 @@ module Formi9
       :per_page,
       :timeout,
       :open_timeout,
+      :b2b_encryption_algorithm,
+      :b2b_encryption_cipher_mode,
+      :b2b_encryption_key,
+      :b2b_encryption_iv,
     ].freeze
 
     # By default, don't set an access token
@@ -48,6 +53,10 @@ module Formi9
     #
     # @note JSON is the only available format at this time
     DEFAULT_FORMAT = :json
+
+    DEFAULT_B2B_ENCRYPTION_ALGORITHM = OpenSSL::Cipher::AES256
+
+    DEFAULT_B2B_ENCRYPTION_CIPHER_MODE = :CBC
 
     # By default, don't use a proxy server
     DEFAULT_PROXY = nil
@@ -89,6 +98,8 @@ module Formi9
       self.per_page           = DEFAULT_PER_PAGE
       self.timeout            = DEFAULT_TIMEOUT
       self.open_timeout       = DEFAULT_OPEN_TIMEOUT
+      self.b2b_encryption_algorithm   = DEFAULT_B2B_ENCRYPTION_ALGORITHM
+      self.b2b_encryption_cipher_mode = DEFAULT_B2B_ENCRYPTION_CIPHER_MODE
     end
   end
 end


### PR DESCRIPTION
How to config it?


```ruby
Formi9.configure do |config|
  config.partner_id = 'Your Partner Id'
  config.username = 'Your username'
  config.password = 'Your password'
  # config.b2b_encryption_key = 'key'
  # config.b2b_encryption_iv = 'iv'
end
```

How to use it?

```
Formi9.b2b_direct_link(
  b2b_username: 'Ryan Lv',
  company_id: 'democompany',
  request_id: 'ba24c5eb-31f1-4650-803b-c8725fbe7682',
  result_id: '28542059',
)
```