### PR TITLE
Add retry to Faraday Connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ doc/*
 log/*
 pkg/*
 .idea/*
+
+# Vim Swap file
+*.swp

--- a/lib/formi9/connection.rb
+++ b/lib/formi9/connection.rb
@@ -24,7 +24,7 @@ module Formi9
         conn.request :json
 
         conn.use FaradayMiddleWare::RaiseFormi9HttpException
-        conn.request :retry, max: 3, interval: 0.1, retry_statuses: [500, 502, 503, 504]
+        conn.request :retry, max: 3, interval: 0.1, exceptions: [Errno::ECONNREFUSED, Faraday::ConnectionFailed]
         conn.response :json, content_type: /\bjson$/
         conn.adapter Faraday.default_adapter
       end

--- a/lib/formi9/connection.rb
+++ b/lib/formi9/connection.rb
@@ -19,11 +19,12 @@ module Formi9
       Faraday::Connection.new(options) do |conn|
         conn.authorization :Bearer, access_token
         # https://github.com/lostisland/faraday/issues/417#issuecomment-223413386
-        conn.options[:timeout] = timeout 
-        conn.options[:open_timeout] = open_timeout 
+        conn.options[:timeout] = timeout
+        conn.options[:open_timeout] = open_timeout
         conn.request :json
 
         conn.use FaradayMiddleWare::RaiseFormi9HttpException
+        conn.request :retry, max: 3, interval: 0.1, retry_statuses: [500, 502, 503, 504]
         conn.response :json, content_type: /\bjson$/
         conn.adapter Faraday.default_adapter
       end

--- a/lib/formi9/version.rb
+++ b/lib/formi9/version.rb
@@ -1,3 +1,3 @@
 module Formi9
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
Add retry with an interval of 0.1 sec when response status in [500, 502, 503, 504]

Trello: https://trello.com/c/eQzqjxRM/128-fix-sentry-error-add-retry-for-formi9com

Ref: https://github.com/lostisland/faraday/blob/main/docs/middleware/request/retry.md